### PR TITLE
🔖 Release v1.0.3-beta.0

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -11,7 +11,7 @@
     <PackageId>PercyIO.Playwright</PackageId>
     <Description>Percy for Playwright Driver API .NET Bindings</Description>
     <PackageTags>playwright;percy;visual;testing</PackageTags>
-    <Version>1.0.2</Version>
+    <Version>1.0.3-beta.0</Version>
     <Company>BrowserStack</Company>
     <Copyright>Copyright BrowserStack</Copyright>
     <Authors>BrowserStack</Authors>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "test": "percy exec --testing -- dotnet test"
   },
   "devDependencies": {
-    "@percy/cli": "1.31.10-beta.0"
+    "@percy/cli": "1.31.10"
   }
 }


### PR DESCRIPTION
🔖 Release v1.0.3-beta.0

- Updated `Version` in `Percy/Percy.csproj` from `1.0.2` to `1.0.3-beta.0`
- Updated `@percy/cli` in `package.json` from `1.31.10-beta.0` to `1.31.10` (stable)