### PR TITLE
feat: PER-7348 add waitForReady() call before serialize()

### DIFF
--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -239,6 +239,49 @@ namespace PercyIO.Playwright.Tests
             }
             Percy.Enabled = oldEnabledFn;
         }
+
+        // ─── Readiness gate (PER-7348) ─────────────────────────────────────
+
+        [Fact]
+        public void PostsSnapshotWithReadinessEnabled()
+        {
+            // Readiness preset "balanced" — readiness runs before serialize.
+            // The snapshot should still post successfully regardless of whether the
+            // connected CLI has PercyDOM.waitForReady (backward-compat guard in code).
+            Percy.Snapshot(_fixture.Page, "readiness-balanced", new {
+                readiness = new { preset = "balanced" }
+            });
+
+            JsonElement data = Request("/test/logs");
+            var logs = data.GetProperty("logs").EnumerateArray()
+                .Select(log => log.GetProperty("message").GetString())
+                .Where(msg => msg != null)
+                .Select(msg => msg!)
+                .ToList();
+
+            Assert.Contains("Received snapshot: readiness-balanced", logs);
+            Assert.Contains("- domSnapshot: true", logs);
+        }
+
+        [Fact]
+        public void PostsSnapshotWithReadinessDisabled()
+        {
+            // Disabled preset — SDK must skip the waitForReady evaluate entirely.
+            // Snapshot still posts normally.
+            Percy.Snapshot(_fixture.Page, "readiness-disabled", new {
+                readiness = new { preset = "disabled" }
+            });
+
+            JsonElement data = Request("/test/logs");
+            var logs = data.GetProperty("logs").EnumerateArray()
+                .Select(log => log.GetProperty("message").GetString())
+                .Where(msg => msg != null)
+                .Select(msg => msg!)
+                .ToList();
+
+            Assert.Contains("Received snapshot: readiness-disabled", logs);
+            Assert.Contains("- domSnapshot: true", logs);
+        }
     }
 
     // ─── Cookies Capture Tests ────────────────────────────────────────────────

--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -240,7 +240,7 @@ namespace PercyIO.Playwright.Tests
             Percy.Enabled = oldEnabledFn;
         }
 
-        // ─── Readiness gate (PER-7348) ─────────────────────────────────────
+        // ─── Readiness gate ─────────────────────────────────────
 
         [Fact]
         public void PostsSnapshotWithReadinessEnabled()

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -374,7 +374,7 @@ namespace PercyIO.Playwright
             }
         }
 
-        // Readiness gate (PER-7348). Runs PercyDOM.waitForReady via EvaluateSync;
+        // Readiness gate. Runs PercyDOM.waitForReady via EvaluateSync;
         // Playwright auto-awaits the returned Promise. Checks typeof in-browser so
         // older CLI versions without the method are a graceful no-op. Returns
         // diagnostics to attach to the domSnapshot, or null.
@@ -430,7 +430,7 @@ namespace PercyIO.Playwright
 
         private static object GetSerializedDom(IPage page, Dictionary<string, object>? options, string cookiesJson, int? width = null)
         {
-            // Readiness gate before serialize (PER-7348). Graceful on old CLI.
+            // Readiness gate before serialize. Graceful on old CLI.
             object? readinessDiagnostics = WaitForReady(page, options);
 
             string opts = JsonSerializer.Serialize(options);

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -374,12 +374,75 @@ namespace PercyIO.Playwright
             }
         }
 
+        // Readiness gate (PER-7348). Runs PercyDOM.waitForReady via EvaluateSync;
+        // Playwright auto-awaits the returned Promise. Checks typeof in-browser so
+        // older CLI versions without the method are a graceful no-op. Returns
+        // diagnostics to attach to the domSnapshot, or null.
+        private static object? WaitForReady(IPage page, Dictionary<string, object>? options)
+        {
+            string readinessJson = "{}";
+            if (options != null && options.TryGetValue("readiness", out var perSnapshot) && perSnapshot != null)
+            {
+                readinessJson = JsonSerializer.Serialize(perSnapshot);
+            }
+            else if (cliConfig is JsonElement configElement &&
+                     configElement.ValueKind == JsonValueKind.Object &&
+                     configElement.TryGetProperty("snapshot", out JsonElement snapshotElement) &&
+                     snapshotElement.ValueKind == JsonValueKind.Object &&
+                     snapshotElement.TryGetProperty("readiness", out JsonElement readinessElement) &&
+                     readinessElement.ValueKind == JsonValueKind.Object)
+            {
+                readinessJson = readinessElement.GetRawText();
+            }
+
+            // Skip when preset is disabled
+            try
+            {
+                using JsonDocument doc = JsonDocument.Parse(readinessJson);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                    doc.RootElement.TryGetProperty("preset", out JsonElement presetElement) &&
+                    presetElement.ValueKind == JsonValueKind.String &&
+                    presetElement.GetString() == "disabled")
+                {
+                    return null;
+                }
+            }
+            catch { /* fall through on malformed JSON */ }
+
+            string script =
+                "(() => {"
+                + $"  var cfg = {readinessJson};"
+                + "  if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {"
+                + "    return PercyDOM.waitForReady(cfg);"
+                + "  }"
+                + "  return null;"
+                + "})()";
+            try
+            {
+                return PercyPlaywrightDriver.EvaluateSync<object>(page, script);
+            }
+            catch (Exception e)
+            {
+                Log($"waitForReady failed, proceeding to serialize: {e.Message}", "debug");
+                return null;
+            }
+        }
+
         private static object GetSerializedDom(IPage page, Dictionary<string, object>? options, string cookiesJson, int? width = null)
         {
+            // Readiness gate before serialize (PER-7348). Graceful on old CLI.
+            object? readinessDiagnostics = WaitForReady(page, options);
+
             string opts = JsonSerializer.Serialize(options);
             string widthAssignment = width.HasValue ? $"dom.width = {width.Value};" : "";
             string script = $"(() => {{ const dom = PercyDOM.serialize({opts}); dom.cookies = {cookiesJson}; {widthAssignment} return dom; }})()";
             var domSnapshot = PercyPlaywrightDriver.EvaluateSync<object>(page, script);
+
+            // Attach readiness diagnostics so the CLI can log timing and pass/fail
+            if (readinessDiagnostics != null && domSnapshot is IDictionary<string, object> readinessDict)
+            {
+                readinessDict["readiness_diagnostics"] = readinessDiagnostics;
+            }
 
             // Process CORS IFrames
             try


### PR DESCRIPTION
## Summary

Adopts the readiness gate from [percy/cli#2184](https://github.com/percy/cli/pull/2184) (PER-7348). New `WaitForReady(page, options)` helper runs `PercyDOM.waitForReady(config)` via `EvaluateSync` inside `GetSerializedDom`. Playwright auto-awaits the returned Promise. The result is attached to the domSnapshot dictionary as `readiness_diagnostics`.

### Contract

- Config precedence: `options["readiness"]` → `cliConfig.snapshot.readiness` → empty (CLI applies `balanced` default)
- Backward compat: in-browser `typeof PercyDOM.waitForReady === 'function'` guard
- Disabled preset short-circuits (no evaluate)
- Graceful: any exception → swallowed at debug; serialize still runs

### Tests

Two new `[Fact]` tests in `UnitTests`:

- ✅ **PostsSnapshotWithReadinessEnabled** — snapshot with `readiness: { preset: "balanced" }` posts successfully
- ✅ **PostsSnapshotWithReadinessDisabled** — snapshot with `readiness: { preset: "disabled" }` posts successfully (verifies the disabled-preset path doesn't break serialize)

These use the existing integration test fixture (live CLI + Playwright browser). They assert the snapshot reaches the mock server regardless of readiness state.

## Test results

| Check | Status | Notes |
|---|---|---|
| Build (`dotnet build`) | ✅ pass, 0 errors | Pre-existing warnings only |
| Unit tests (`dotnet test`) | ⚠️ not executed locally | Test project is integration-only — requires a running Percy CLI + Playwright browsers |
| Smoke test | ⚠️ skipped: toolchain missing | |

## Related

- CLI PR: [percy/cli#2184](https://github.com/percy/cli/pull/2184)