### PR TITLE
fix: merge .percy.yml config options with snapshot options for serializeDOM

### DIFF
--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -1108,6 +1108,43 @@ namespace PercyIO.Playwright.Tests
                 ResetCliConfig();
             }
         }
+
+        [Fact]
+        public void NestedObjectsDeepMergeWithPerCallWinningAtLeaves()
+        {
+            try
+            {
+                // .percy.yml config supplies a nested discovery block with two leaves.
+                SetCliConfigSnapshot("{\"discovery\":{\"networkIdleTimeout\":50,\"disableCache\":false}}");
+
+                // Per-call option only overrides one leaf inside the nested discovery object.
+                var merged = InvokeMergeSnapshotOptions(new Dictionary<string, object>
+                {
+                    {
+                        "discovery", new Dictionary<string, object>
+                        {
+                            { "disableCache", true }
+                        }
+                    }
+                });
+
+                // The nested object must be deep-merged, not replaced wholesale.
+                Assert.True(merged.ContainsKey("discovery"));
+                var discovery = Assert.IsType<Dictionary<string, object>>(merged["discovery"]);
+
+                // Config-only nested leaf survives the merge.
+                Assert.True(discovery.ContainsKey("networkIdleTimeout"));
+                Assert.Equal(50, discovery["networkIdleTimeout"]);
+
+                // Per-call nested leaf wins over the config value.
+                Assert.True(discovery.ContainsKey("disableCache"));
+                Assert.Equal(true, discovery["disableCache"]);
+            }
+            finally
+            {
+                ResetCliConfig();
+            }
+        }
     }
 
     // ─── Region Tests ──────────────────────────────────────────────────────────

--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -1041,6 +1041,75 @@ namespace PercyIO.Playwright.Tests
         }
     }
 
+    // ─── Config ⇄ Per-Snapshot Merge Precedence Tests ─────────────────────────
+
+    public class MergeSnapshotOptionsTests
+    {
+        // Seeds Percy's private cliConfig with a `.percy.yml`-style snapshot block via the
+        // internal setCliConfig hook (reached by reflection, the same technique CorsFrameTests
+        // uses for non-public members). No real browser is involved.
+        private static void SetCliConfigSnapshot(string snapshotJson)
+        {
+            var configJson = $"{{\"snapshot\":{snapshotJson}}}";
+            using JsonDocument doc = JsonDocument.Parse(configJson);
+            JsonElement config = doc.RootElement.Clone();
+
+            MethodInfo? setCliConfig = typeof(Percy).GetMethod(
+                "setCliConfig",
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            Assert.NotNull(setCliConfig);
+            setCliConfig!.Invoke(null, new object[] { config });
+        }
+
+        private static void ResetCliConfig()
+        {
+            FieldInfo? cliConfigField = typeof(Percy).GetField(
+                "cliConfig",
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            cliConfigField?.SetValue(null, null);
+        }
+
+        private static Dictionary<string, object> InvokeMergeSnapshotOptions(Dictionary<string, object>? options)
+        {
+            MethodInfo? merge = typeof(Percy).GetMethod(
+                "MergeSnapshotOptions",
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            Assert.NotNull(merge);
+            return (Dictionary<string, object>)merge!.Invoke(null, new object?[] { options })!;
+        }
+
+        [Fact]
+        public void PerSnapshotOptionOverridesConfigWhileConfigOnlyKeysAreKept()
+        {
+            try
+            {
+                // .percy.yml config supplies a config-only key (enableJavaScript) and a
+                // percyCSS that the per-call option must override.
+                SetCliConfigSnapshot("{\"enableJavaScript\":true,\"percyCSS\":\"FROM_CONFIG\"}");
+
+                // Per-call option only sets percyCSS — this is what reaches PercyDOM.serialize.
+                var merged = InvokeMergeSnapshotOptions(new Dictionary<string, object>
+                {
+                    { "percyCSS", "FROM_CALL" }
+                });
+
+                // Config-only key survives the merge.
+                Assert.True(merged.ContainsKey("enableJavaScript"));
+                Assert.Equal(true, merged["enableJavaScript"]);
+
+                // Per-call value wins over the config value.
+                Assert.Equal("FROM_CALL", merged["percyCSS"]);
+            }
+            finally
+            {
+                ResetCliConfig();
+            }
+        }
+    }
+
     // ─── Region Tests ──────────────────────────────────────────────────────────
 
     public class RegionTests

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -665,6 +665,34 @@ namespace PercyIO.Playwright
             return domSnapshots;
         }
 
+        private static Dictionary<string, object> MergeSnapshotOptions(Dictionary<string, object>? options)
+        {
+            var merged = new Dictionary<string, object>();
+            if (cliConfig is JsonElement configElement &&
+                configElement.ValueKind == JsonValueKind.Object &&
+                configElement.TryGetProperty("snapshot", out JsonElement snapshotElement) &&
+                snapshotElement.ValueKind == JsonValueKind.Object)
+            {
+                foreach (JsonProperty prop in snapshotElement.EnumerateObject())
+                {
+                    merged[prop.Name] = prop.Value.ValueKind switch
+                    {
+                        JsonValueKind.True => true,
+                        JsonValueKind.False => false,
+                        JsonValueKind.Number => prop.Value.TryGetInt32(out int intVal) ? intVal : (object)prop.Value.GetDouble(),
+                        JsonValueKind.String => prop.Value.GetString(),
+                        _ => prop.Value
+                    };
+                }
+            }
+            if (options != null)
+            {
+                foreach (var kvp in options)
+                    merged[kvp.Key] = kvp.Value;
+            }
+            return merged;
+        }
+
         private static bool IsResponsiveSnapshotCapture(Dictionary<string, object>? options)
         {
             if (cliConfig is JsonElement configElement)
@@ -723,12 +751,16 @@ namespace PercyIO.Playwright
 
                 // Convert IEnumerable to Dictionary for proper JSON serialization
                 var optionsDict = options?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+                // Merge .percy.yml config options with snapshot options (snapshot options take priority)
+                var mergedOptions = MergeSnapshotOptions(optionsDict);
+
                 // CookiesAsync has no sync equivalent; block with .GetAwaiter().GetResult() to fetch cookies before serializing the DOM
                 var cookies = page.Context.CookiesAsync().GetAwaiter().GetResult();
                 string cookiesJson = JsonSerializer.Serialize(cookies);
-                object domSnapshot = IsResponsiveSnapshotCapture(optionsDict)
-                    ? CaptureResponsiveDom(page, optionsDict, cookiesJson)
-                    : GetSerializedDom(page, optionsDict, cookiesJson);
+                object domSnapshot = IsResponsiveSnapshotCapture(mergedOptions)
+                    ? CaptureResponsiveDom(page, mergedOptions, cookiesJson)
+                    : GetSerializedDom(page, mergedOptions, cookiesJson);
 
                 Options snapshotOptions = new Options {
                     { "clientInfo", CLIENT_INFO },

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -773,8 +773,13 @@ namespace PercyIO.Playwright
                     }
                     return dict;
                 case JsonValueKind.Array:
+                    var items = el.EnumerateArray().ToList();
+                    // All-integer arrays (e.g. config `widths`) must stay List<int> so
+                    // ParseWidthsFromOptions' IEnumerable<int> path recognizes them.
+                    if (items.Count > 0 && items.All(i => i.ValueKind == JsonValueKind.Number && i.TryGetInt32(out _)))
+                        return items.Select(i => i.GetInt32()).ToList();
                     var list = new List<object>();
-                    foreach (JsonElement item in el.EnumerateArray())
+                    foreach (JsonElement item in items)
                     {
                         var converted = JsonElementToObjectDeep(item);
                         if (converted != null)

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -738,22 +738,83 @@ namespace PercyIO.Playwright
             {
                 foreach (JsonProperty prop in snapshotElement.EnumerateObject())
                 {
-                    merged[prop.Name] = prop.Value.ValueKind switch
-                    {
-                        JsonValueKind.True => true,
-                        JsonValueKind.False => false,
-                        JsonValueKind.Number => prop.Value.TryGetInt32(out int intVal) ? intVal : (object)prop.Value.GetDouble(),
-                        JsonValueKind.String => prop.Value.GetString(),
-                        _ => prop.Value
-                    };
+                    // Recursively convert config values so nested JSON
+                    // objects become Dictionary<string, object> and can be
+                    // deep-merged with per-call options below.
+                    var converted = JsonElementToObjectDeep(prop.Value);
+                    if (converted != null)
+                        merged[prop.Name] = converted;
                 }
             }
             if (options != null)
             {
-                foreach (var kvp in options)
-                    merged[kvp.Key] = kvp.Value;
+                // Deep-merge: nested objects merge recursively (per-call wins at
+                // leaves), arrays/scalars replace. Matches the JS sdk-utils fix.
+                merged = DeepMerge(merged, options);
             }
             return merged;
+        }
+
+        // Recursively converts a JSON element into plain CLR objects:
+        // Object -> Dictionary<string, object> (recursive),
+        // Array  -> List<object> (recursive),
+        // primitives -> bool / int / double / string.
+        private static object? JsonElementToObjectDeep(JsonElement el)
+        {
+            switch (el.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    var dict = new Dictionary<string, object>();
+                    foreach (JsonProperty prop in el.EnumerateObject())
+                    {
+                        var converted = JsonElementToObjectDeep(prop.Value);
+                        if (converted != null)
+                            dict[prop.Name] = converted;
+                    }
+                    return dict;
+                case JsonValueKind.Array:
+                    var list = new List<object>();
+                    foreach (JsonElement item in el.EnumerateArray())
+                    {
+                        var converted = JsonElementToObjectDeep(item);
+                        if (converted != null)
+                            list.Add(converted);
+                    }
+                    return list;
+                case JsonValueKind.True:
+                    return true;
+                case JsonValueKind.False:
+                    return false;
+                case JsonValueKind.Number:
+                    return el.TryGetInt32(out int intVal) ? (object)intVal : el.GetDouble();
+                case JsonValueKind.String:
+                    return el.GetString();
+                default:
+                    return null;
+            }
+        }
+
+        // Deep-merges override into a copy of baseDict: when a key exists in both
+        // and both values are Dictionary<string, object>, recurse; otherwise the
+        // override value wins (arrays and scalars replace).
+        private static Dictionary<string, object> DeepMerge(
+            Dictionary<string, object> baseDict, Dictionary<string, object> overrideDict)
+        {
+            var result = new Dictionary<string, object>(baseDict);
+            foreach (var kvp in overrideDict)
+            {
+                if (result.TryGetValue(kvp.Key, out var existing) &&
+                    existing is Dictionary<string, object> existingDict &&
+                    kvp.Value is Dictionary<string, object> overrideNested)
+                {
+                    result[kvp.Key] = DeepMerge(existingDict, overrideNested);
+                }
+                else
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+            return result;
         }
 
         private static bool IsResponsiveSnapshotCapture(Dictionary<string, object>? options)


### PR DESCRIPTION
## Summary
- Config options from `.percy.yml` were not being passed to `PercyDOM.serialize()`
- Only per-snapshot options were used for DOM serialization
- Adds `MergeSnapshotOptions()` helper that extracts `cliConfig.snapshot` properties and merges with user options, with per-snapshot options taking priority

## Test plan
- [ ] Existing tests pass
- [ ] Verify `.percy.yml` config options are applied during DOM serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)