### PR TITLE
Add closed shadow DOM capture via CDP

### DIFF
--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -996,6 +996,82 @@ namespace PercyIO.Playwright.Tests
                 "http://localhost:5338/test/snapshot"
             ));
         }
+
+        // The expanded unsupported-scheme list: every entry should short-circuit
+        // to false (not cross-origin) so we never try to treat the iframe as a
+        // CORS-capturable target. Mirrors the JS SDKs' isUnsupportedIframeSrc.
+        [Theory]
+        [InlineData("chrome://settings/")]
+        [InlineData("chrome-extension://abcdef/popup.html")]
+        [InlineData("devtools://inspect")]
+        [InlineData("edge://favorites")]
+        [InlineData("opera://about")]
+        [InlineData("view-source:https://example.com")]
+        [InlineData("data:text/html,<h1>hi</h1>")]
+        [InlineData("javascript:void(0)")]
+        [InlineData("vbscript:msgbox")]
+        [InlineData("blob:https://example.com/uuid")]
+        public void UnsupportedSchemeIsTreatedAsNotCrossOrigin(string frameUrl)
+        {
+            Assert.False(InvokeIsCrossOriginFrame(frameUrl, "https://example.com/"));
+        }
+
+        [Fact]
+        public void EmptyFrameUrlIsNotCrossOrigin()
+        {
+            Assert.False(InvokeIsCrossOriginFrame("", "https://example.com/"));
+        }
+
+        [Fact]
+        public void UnsupportedSchemeIsCaseInsensitive()
+        {
+            // Real-world frame URLs sometimes carry uppercase scheme parts
+            // (ABOUT:Blank from some legacy browsers); ToLowerInvariant in
+            // IsCrossOriginFrame must catch them.
+            Assert.False(InvokeIsCrossOriginFrame("ABOUT:Blank", "https://example.com/"));
+            Assert.False(InvokeIsCrossOriginFrame("JavaScript:void(0)", "https://example.com/"));
+        }
+    }
+
+    public class HttpClientInitTests
+    {
+        [Fact]
+        public void GetHttpClient_AlwaysReturnsClientWithTenMinuteTimeout()
+        {
+            // Reset to force getHttpClient's first-caller path. The DCL behind
+            // the volatile _http field must hand back a fully-initialized client
+            // whose Timeout is already set — this is the invariant the
+            // volatile keyword exists to preserve under contention.
+            var field = typeof(Percy).GetField("_http",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(field);
+            field!.SetValue(null, null);
+
+            var method = typeof(Percy).GetMethod("getHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var client = (HttpClient)method!.Invoke(null, null)!;
+
+            Assert.NotNull(client);
+            Assert.Equal(TimeSpan.FromMinutes(10), client.Timeout);
+        }
+
+        [Fact]
+        public void GetHttpClient_IsIdempotentAcrossCalls()
+        {
+            var field = typeof(Percy).GetField("_http",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            field!.SetValue(null, null);
+
+            var method = typeof(Percy).GetMethod("getHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            var first = method!.Invoke(null, null);
+            var second = method.Invoke(null, null);
+
+            // Same instance — the DCL pattern must NOT build a new client per
+            // call once one is published.
+            Assert.Same(first, second);
+        }
     }
 
     // ─── Region Tests ──────────────────────────────────────────────────────────

--- a/Percy.Test/Percy.Test.cs
+++ b/Percy.Test/Percy.Test.cs
@@ -1033,6 +1033,13 @@ namespace PercyIO.Playwright.Tests
         }
     }
 
+    // Serialize HttpClient state mutations: these tests null out Percy's static
+    // _http field via reflection. Without a [Collection] gate, xUnit may run them
+    // in parallel with other test classes that also touch Percy's static HTTP
+    // state (UnitTests / CookiesCaptureTests / ResponsiveCaptureTests /
+    // CorsIframeIntegrationTests — all members of "PercySerialTests"), racing
+    // the field clearing against an in-flight Request() call.
+    [Collection("PercySerialTests")]
     public class HttpClientInitTests
     {
         [Fact]
@@ -1071,6 +1078,196 @@ namespace PercyIO.Playwright.Tests
             // Same instance — the DCL pattern must NOT build a new client per
             // call once one is published.
             Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void GetHttpClient_SerializedCollectionSmoke()
+        {
+            // Smoke test confirming the [Collection("PercySerialTests")] gate on
+            // this class still lets a basic getHttpClient() call succeed even when
+            // running serialized with the rest of the Percy-state-mutating tests.
+            // If this ever fails it points at a regression in the serialization
+            // setup itself, not the DCL logic.
+            var method = typeof(Percy).GetMethod("getHttpClient",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var client = (HttpClient)method!.Invoke(null, null)!;
+            Assert.NotNull(client);
+        }
+    }
+
+    // ─── WalkNodes (closed shadow root discovery) Unit Tests ──────────────────
+
+    public class WalkNodesTests
+    {
+        // WalkNodes' signature is (JsonElement, List<(int, int)>, string).
+        // ValueTuple parameters survive reflection round-trips fine — invoke
+        // it with a synthesized CDP DOM payload to assert the same-origin
+        // iframe recursion path.
+        private static List<(int hostId, int shadowId)> InvokeWalkNodes(string json, string pageUrl)
+        {
+            var doc = JsonDocument.Parse(json);
+            var pairs = new List<(int hostId, int shadowId)>();
+            var method = typeof(Percy).GetMethod(
+                "WalkNodes",
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            Assert.NotNull(method);
+            method!.Invoke(null, new object[] { doc.RootElement, pairs, pageUrl });
+            return pairs;
+        }
+
+        [Fact]
+        public void SameOriginIframe_ContentDocumentClosedShadowRoots_AreCollected()
+        {
+            // A CDP DOM tree containing an iframe whose contentDocument is
+            // same-origin (documentURL host == pageUrl host) and whose body
+            // hosts a closed shadow root. WalkNodes must recurse INTO that
+            // contentDocument and add the (host, shadowRoot) pair — without
+            // this fix the iframe node would short-circuit on the
+            // contentDocument check and the closed shadow root would be lost.
+            string json = @"{
+                ""backendNodeId"": 1,
+                ""nodeName"": ""#document"",
+                ""children"": [
+                    {
+                        ""backendNodeId"": 2,
+                        ""nodeName"": ""IFRAME"",
+                        ""contentDocument"": {
+                            ""backendNodeId"": 3,
+                            ""nodeName"": ""#document"",
+                            ""documentURL"": ""http://localhost:5338/inner"",
+                            ""children"": [
+                                {
+                                    ""backendNodeId"": 4,
+                                    ""nodeName"": ""DIV"",
+                                    ""shadowRoots"": [
+                                        {
+                                            ""backendNodeId"": 5,
+                                            ""shadowRootType"": ""closed""
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }";
+
+            var pairs = InvokeWalkNodes(json, "http://localhost:5338/outer");
+
+            Assert.Single(pairs);
+            Assert.Equal(4, pairs[0].hostId);
+            Assert.Equal(5, pairs[0].shadowId);
+        }
+
+        [Fact]
+        public void CrossOriginIframe_ContentDocumentClosedShadowRoots_AreSkipped()
+        {
+            // Same payload shape but the iframe's documentURL is on a different
+            // host — cross-origin contentDocument lives in its own JS realm,
+            // so the parent-page WeakMap can't reach it. WalkNodes must NOT
+            // recurse and the closed shadow pair must NOT be collected here
+            // (the per-frame ProcessFrame path handles it instead).
+            string json = @"{
+                ""backendNodeId"": 1,
+                ""nodeName"": ""#document"",
+                ""children"": [
+                    {
+                        ""backendNodeId"": 2,
+                        ""nodeName"": ""IFRAME"",
+                        ""contentDocument"": {
+                            ""backendNodeId"": 3,
+                            ""nodeName"": ""#document"",
+                            ""documentURL"": ""http://other.example.com/inner"",
+                            ""children"": [
+                                {
+                                    ""backendNodeId"": 4,
+                                    ""nodeName"": ""DIV"",
+                                    ""shadowRoots"": [
+                                        {
+                                            ""backendNodeId"": 5,
+                                            ""shadowRootType"": ""closed""
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }";
+
+            var pairs = InvokeWalkNodes(json, "http://localhost:5338/outer");
+
+            Assert.Empty(pairs);
+        }
+
+        [Fact]
+        public void TopLevelClosedShadowRoot_StillCollected()
+        {
+            // Regression guard: the new contentDocument branch must not
+            // break the original top-level shadow-root collection.
+            string json = @"{
+                ""backendNodeId"": 1,
+                ""nodeName"": ""#document"",
+                ""children"": [
+                    {
+                        ""backendNodeId"": 10,
+                        ""nodeName"": ""DIV"",
+                        ""shadowRoots"": [
+                            {
+                                ""backendNodeId"": 11,
+                                ""shadowRootType"": ""closed""
+                            }
+                        ]
+                    }
+                ]
+            }";
+
+            var pairs = InvokeWalkNodes(json, "http://localhost:5338/page");
+
+            Assert.Single(pairs);
+            Assert.Equal(10, pairs[0].hostId);
+            Assert.Equal(11, pairs[0].shadowId);
+        }
+
+        [Fact]
+        public void OpenShadowRoot_InSameOriginIframe_IsNotCollected()
+        {
+            // Same-origin iframe with an OPEN shadow root — open roots don't
+            // need WeakMap exposure (PercyDOM serializes them natively), so
+            // even though we recurse, only closed roots should be collected.
+            string json = @"{
+                ""backendNodeId"": 1,
+                ""nodeName"": ""#document"",
+                ""children"": [
+                    {
+                        ""backendNodeId"": 2,
+                        ""nodeName"": ""IFRAME"",
+                        ""contentDocument"": {
+                            ""backendNodeId"": 3,
+                            ""nodeName"": ""#document"",
+                            ""documentURL"": ""http://localhost:5338/inner"",
+                            ""children"": [
+                                {
+                                    ""backendNodeId"": 4,
+                                    ""nodeName"": ""DIV"",
+                                    ""shadowRoots"": [
+                                        {
+                                            ""backendNodeId"": 5,
+                                            ""shadowRootType"": ""open""
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }";
+
+            var pairs = InvokeWalkNodes(json, "http://localhost:5338/outer");
+
+            Assert.Empty(pairs);
         }
     }
 

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -304,6 +304,107 @@ namespace PercyIO.Playwright
 
         public class Options : Dictionary<string, object> { }
 
+        /// <summary>
+        /// Use CDP to discover closed shadow roots and expose them to PercyDOM.serialize().
+        /// </summary>
+        private static void ExposeClosedShadowRoots(IPage page)
+        {
+            ICDPSession? cdpSession = null;
+            try
+            {
+                cdpSession = page.Context.NewCDPSessionAsync(page).GetAwaiter().GetResult();
+            }
+            catch (Exception err)
+            {
+                Log($"CDP session unavailable: {err.Message}", "debug");
+                return;
+            }
+
+            try
+            {
+                cdpSession.SendAsync("DOM.enable").GetAwaiter().GetResult();
+
+                var docResult = cdpSession.SendAsync("DOM.getDocument", new Dictionary<string, object>
+                {
+                    { "depth", -1 },
+                    { "pierce", true }
+                }).GetAwaiter().GetResult();
+
+                var root = docResult.Value.GetProperty("root");
+
+                var closedPairs = new List<(int hostId, int shadowId)>();
+                WalkNodes(root, closedPairs);
+
+                if (closedPairs.Count == 0) return;
+
+                Log($"Found {closedPairs.Count} closed shadow root(s), exposing via CDP", "debug");
+
+                page.EvaluateAsync("() => { window.__percyClosedShadowRoots = window.__percyClosedShadowRoots || new WeakMap(); }")
+                    .GetAwaiter().GetResult();
+
+                foreach (var (hostId, shadowId) in closedPairs)
+                {
+                    var hostResult = cdpSession.SendAsync("DOM.resolveNode", new Dictionary<string, object>
+                    {
+                        { "backendNodeId", hostId }
+                    }).GetAwaiter().GetResult();
+                    var hostObjectId = hostResult.Value.GetProperty("object").GetProperty("objectId").GetString();
+
+                    var shadowResult = cdpSession.SendAsync("DOM.resolveNode", new Dictionary<string, object>
+                    {
+                        { "backendNodeId", shadowId }
+                    }).GetAwaiter().GetResult();
+                    var shadowObjectId = shadowResult.Value.GetProperty("object").GetProperty("objectId").GetString();
+
+                    cdpSession.SendAsync("Runtime.callFunctionOn", new Dictionary<string, object>
+                    {
+                        { "functionDeclaration", "function(shadowRoot) { window.__percyClosedShadowRoots.set(this, shadowRoot); }" },
+                        { "objectId", hostObjectId! },
+                        { "arguments", new[] { new Dictionary<string, object> { { "objectId", shadowObjectId! } } } }
+                    }).GetAwaiter().GetResult();
+                }
+            }
+            catch (Exception err)
+            {
+                Log($"Could not expose closed shadow roots via CDP: {err.Message}", "debug");
+            }
+            finally
+            {
+                if (cdpSession != null)
+                {
+                    try { cdpSession.DetachAsync().GetAwaiter().GetResult(); } catch { }
+                }
+            }
+        }
+
+        private static void WalkNodes(JsonElement node, List<(int hostId, int shadowId)> closedPairs)
+        {
+            if (node.TryGetProperty("contentDocument", out _)) return;
+
+            if (node.TryGetProperty("shadowRoots", out var shadowRoots))
+            {
+                foreach (var sr in shadowRoots.EnumerateArray())
+                {
+                    if (sr.TryGetProperty("shadowRootType", out var type) && type.GetString() == "closed")
+                    {
+                        closedPairs.Add((
+                            node.GetProperty("backendNodeId").GetInt32(),
+                            sr.GetProperty("backendNodeId").GetInt32()
+                        ));
+                    }
+                    WalkNodes(sr, closedPairs);
+                }
+            }
+
+            if (node.TryGetProperty("children", out var children))
+            {
+                foreach (var child in children.EnumerateArray())
+                {
+                    WalkNodes(child, closedPairs);
+                }
+            }
+        }
+
         private static bool IsCrossOriginFrame(string frameUrl, string pageUrl)
         {
             if (frameUrl == "about:blank")
@@ -720,6 +821,9 @@ namespace PercyIO.Playwright
             {
                 if (PercyPlaywrightDriver.EvaluateSync<bool>(page, "!!window.PercyDOM") == false)
                     PercyPlaywrightDriver.EvaluateSync<string>(page, GetPercyDOM());
+
+                // Expose closed shadow roots via CDP before serialization
+                ExposeClosedShadowRoots(page);
 
                 // Convert IEnumerable to Dictionary for proper JSON serialization
                 var optionsDict = options?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -92,7 +92,7 @@ namespace PercyIO.Playwright
         {
             if (_http == null)
             {
-                setHttpClient(new HttpClient());
+                _http = new HttpClient();
                 _http.Timeout = TimeSpan.FromMinutes(10);
             }
 
@@ -193,13 +193,13 @@ namespace PercyIO.Playwright
                 return (bool)(_enabled = false);
             }
         };
-        public class Region 
-        { 
-            public RegionElementSelector elementSelector { get; set; } 
-            public RegionPadding padding { get; set; } 
-            public string algorithm { get; set; } 
-            public RegionConfiguration configuration { get; set; } 
-            public RegionAssertion assertion { get; set; } 
+        public class Region
+        {
+            public RegionElementSelector? elementSelector { get; set; }
+            public RegionPadding? padding { get; set; }
+            public string? algorithm { get; set; }
+            public RegionConfiguration? configuration { get; set; }
+            public RegionAssertion? assertion { get; set; }
 
             // Rename the nested class to RegionElementSelector or another unique name
             public class RegionElementSelector 

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -60,7 +60,10 @@ namespace PercyIO.Playwright
             }
         }
 
-        private static HttpClient? _http;
+        // volatile so the unlocked read in getHttpClient sees a fully-published
+        // HttpClient (Timeout set) before the field reference becomes visible
+        // to other threads on weak memory models (e.g. ARM).
+        private static volatile HttpClient? _http;
 
         private static string? sessionType = null;
         private static object? cliConfig;
@@ -355,24 +358,46 @@ namespace PercyIO.Playwright
 
                 foreach (var (hostId, shadowId) in closedPairs)
                 {
-                    var hostResult = cdpSession.SendAsync("DOM.resolveNode", new Dictionary<string, object>
+                    // Per-pair try/catch: if a single host went detached between
+                    // DOM.getDocument and resolveNode (TOCTOU), an unchecked
+                    // GetProperty would throw KeyNotFoundException and abort
+                    // exposure for every remaining pair. Skip the bad one and
+                    // keep going so partial capture still wins.
+                    try
                     {
-                        { "backendNodeId", hostId }
-                    }).GetAwaiter().GetResult();
-                    var hostObjectId = hostResult.Value.GetProperty("object").GetProperty("objectId").GetString();
+                        var hostResult = cdpSession.SendAsync("DOM.resolveNode", new Dictionary<string, object>
+                        {
+                            { "backendNodeId", hostId }
+                        }).GetAwaiter().GetResult();
+                        if (!hostResult.HasValue ||
+                            !hostResult.Value.TryGetProperty("object", out JsonElement hostObj) ||
+                            !hostObj.TryGetProperty("objectId", out JsonElement hostIdEl))
+                            continue;
+                        var hostObjectId = hostIdEl.GetString();
 
-                    var shadowResult = cdpSession.SendAsync("DOM.resolveNode", new Dictionary<string, object>
-                    {
-                        { "backendNodeId", shadowId }
-                    }).GetAwaiter().GetResult();
-                    var shadowObjectId = shadowResult.Value.GetProperty("object").GetProperty("objectId").GetString();
+                        var shadowResult = cdpSession.SendAsync("DOM.resolveNode", new Dictionary<string, object>
+                        {
+                            { "backendNodeId", shadowId }
+                        }).GetAwaiter().GetResult();
+                        if (!shadowResult.HasValue ||
+                            !shadowResult.Value.TryGetProperty("object", out JsonElement shadowObj) ||
+                            !shadowObj.TryGetProperty("objectId", out JsonElement shadowIdEl))
+                            continue;
+                        var shadowObjectId = shadowIdEl.GetString();
 
-                    cdpSession.SendAsync("Runtime.callFunctionOn", new Dictionary<string, object>
+                        if (hostObjectId == null || shadowObjectId == null) continue;
+
+                        cdpSession.SendAsync("Runtime.callFunctionOn", new Dictionary<string, object>
+                        {
+                            { "functionDeclaration", "function(shadowRoot) { window.__percyClosedShadowRoots.set(this, shadowRoot); }" },
+                            { "objectId", hostObjectId },
+                            { "arguments", new[] { new Dictionary<string, object> { { "objectId", shadowObjectId } } } }
+                        }).GetAwaiter().GetResult();
+                    }
+                    catch (Exception perPairErr)
                     {
-                        { "functionDeclaration", "function(shadowRoot) { window.__percyClosedShadowRoots.set(this, shadowRoot); }" },
-                        { "objectId", hostObjectId! },
-                        { "arguments", new[] { new Dictionary<string, object> { { "objectId", shadowObjectId! } } } }
-                    }).GetAwaiter().GetResult();
+                        Log($"Failed to expose one closed shadow root: {perPairErr.Message}", "debug");
+                    }
                 }
             }
             catch (Exception err)

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -326,7 +326,7 @@ namespace PercyIO.Playwright
             ICDPSession? cdpSession = null;
             try
             {
-                cdpSession = page.Context.NewCDPSessionAsync(page).GetAwaiter().GetResult();
+                cdpSession = page.Context.NewCDPSessionAsync(page).ConfigureAwait(false).GetAwaiter().GetResult();
             }
             catch (Exception err)
             {
@@ -336,13 +336,13 @@ namespace PercyIO.Playwright
 
             try
             {
-                cdpSession.SendAsync("DOM.enable").GetAwaiter().GetResult();
+                cdpSession.SendAsync("DOM.enable").ConfigureAwait(false).GetAwaiter().GetResult();
 
                 var docResult = cdpSession.SendAsync("DOM.getDocument", new Dictionary<string, object>
                 {
                     { "depth", -1 },
                     { "pierce", true }
-                }).GetAwaiter().GetResult();
+                }).ConfigureAwait(false).GetAwaiter().GetResult();
 
                 var root = docResult.Value.GetProperty("root");
 
@@ -354,7 +354,7 @@ namespace PercyIO.Playwright
                 Log($"Found {closedPairs.Count} closed shadow root(s), exposing via CDP", "debug");
 
                 page.EvaluateAsync("() => { window.__percyClosedShadowRoots = window.__percyClosedShadowRoots || new WeakMap(); }")
-                    .GetAwaiter().GetResult();
+                    .ConfigureAwait(false).GetAwaiter().GetResult();
 
                 foreach (var (hostId, shadowId) in closedPairs)
                 {
@@ -368,7 +368,7 @@ namespace PercyIO.Playwright
                         var hostResult = cdpSession.SendAsync("DOM.resolveNode", new Dictionary<string, object>
                         {
                             { "backendNodeId", hostId }
-                        }).GetAwaiter().GetResult();
+                        }).ConfigureAwait(false).GetAwaiter().GetResult();
                         if (!hostResult.HasValue ||
                             !hostResult.Value.TryGetProperty("object", out JsonElement hostObj) ||
                             !hostObj.TryGetProperty("objectId", out JsonElement hostIdEl))
@@ -378,7 +378,7 @@ namespace PercyIO.Playwright
                         var shadowResult = cdpSession.SendAsync("DOM.resolveNode", new Dictionary<string, object>
                         {
                             { "backendNodeId", shadowId }
-                        }).GetAwaiter().GetResult();
+                        }).ConfigureAwait(false).GetAwaiter().GetResult();
                         if (!shadowResult.HasValue ||
                             !shadowResult.Value.TryGetProperty("object", out JsonElement shadowObj) ||
                             !shadowObj.TryGetProperty("objectId", out JsonElement shadowIdEl))
@@ -392,7 +392,7 @@ namespace PercyIO.Playwright
                             { "functionDeclaration", "function(shadowRoot) { window.__percyClosedShadowRoots.set(this, shadowRoot); }" },
                             { "objectId", hostObjectId },
                             { "arguments", new[] { new Dictionary<string, object> { { "objectId", shadowObjectId } } } }
-                        }).GetAwaiter().GetResult();
+                        }).ConfigureAwait(false).GetAwaiter().GetResult();
                     }
                     catch (Exception perPairErr)
                     {
@@ -408,7 +408,7 @@ namespace PercyIO.Playwright
             {
                 if (cdpSession != null)
                 {
-                    try { cdpSession.DetachAsync().GetAwaiter().GetResult(); } catch { }
+                    try { cdpSession.DetachAsync().ConfigureAwait(false).GetAwaiter().GetResult(); } catch { }
                 }
             }
         }
@@ -478,7 +478,7 @@ namespace PercyIO.Playwright
             {
                 // Inject Percy DOM into the cross-origin frame
                 // .GetAwaiter().GetResult() is used to block synchronously; EvaluateSync is not available for IFrame, only IPage
-                frame.EvaluateAsync(percyDomScript).GetAwaiter().GetResult();
+                frame.EvaluateAsync(percyDomScript).ConfigureAwait(false).GetAwaiter().GetResult();
 
                 // enableJavaScript=True prevents the standard iframe serialization logic from running.
                 // This is necessary because we're manually handling cross-origin iframe serialization here.
@@ -488,7 +488,7 @@ namespace PercyIO.Playwright
                 // Serialize the frame
                 string serializeScript = $"PercyDOM.serialize({JsonSerializer.Serialize(optionsForFrame)})";
                 // .GetAwaiter().GetResult() is used to block synchronously; EvaluateSync is not available for IFrame, only IPage
-                var iframeSnapshot = frame.EvaluateAsync(serializeScript).GetAwaiter().GetResult();
+                var iframeSnapshot = frame.EvaluateAsync(serializeScript).ConfigureAwait(false).GetAwaiter().GetResult();
 
                 // Get the iframe's element data from the main page context
                 string getDataScript = "(fUrl) => {\n" +
@@ -769,7 +769,7 @@ namespace PercyIO.Playwright
                     {
                         // ReloadAsync has no sync equivalent; block with .GetAwaiter().GetResult() to ensure page is fully loaded before capturing DOM
                         var reloadTask = page.ReloadAsync();
-                        reloadTask.GetAwaiter().GetResult();
+                        reloadTask.ConfigureAwait(false).GetAwaiter().GetResult();
 
                         if (!PercyPlaywrightDriver.EvaluateSync<bool>(page, "!!window.PercyDOM"))
                         {
@@ -876,7 +876,7 @@ namespace PercyIO.Playwright
                 // Convert IEnumerable to Dictionary for proper JSON serialization
                 var optionsDict = options?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
                 // CookiesAsync has no sync equivalent; block with .GetAwaiter().GetResult() to fetch cookies before serializing the DOM
-                var cookies = page.Context.CookiesAsync().GetAwaiter().GetResult();
+                var cookies = page.Context.CookiesAsync().ConfigureAwait(false).GetAwaiter().GetResult();
                 string cookiesJson = JsonSerializer.Serialize(cookies);
                 object domSnapshot = IsResponsiveSnapshotCapture(optionsDict)
                     ? CaptureResponsiveDom(page, optionsDict, cookiesJson)

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -88,14 +88,25 @@ namespace PercyIO.Playwright
             _http = client;
         }
 
+        private static readonly object _httpLock = new object();
+
         internal static HttpClient getHttpClient()
         {
+            // Double-checked locking — concurrent first-callers must not observe an
+            // _http with its default timeout (we set Timeout AFTER assigning the
+            // field, so without the lock another thread could grab the half-built
+            // client). Matches the pattern in Percy.Selenium.
             if (_http == null)
             {
-                setHttpClient(new HttpClient());
-                _http.Timeout = TimeSpan.FromMinutes(10);
+                lock (_httpLock)
+                {
+                    if (_http == null)
+                    {
+                        var client = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+                        _http = client;
+                    }
+                }
             }
-
             return _http;
         }
 
@@ -405,10 +416,22 @@ namespace PercyIO.Playwright
             }
         }
 
+        // Schemes whose iframe content can't be (or shouldn't be) captured —
+        // matches Percy.Selenium's IsUnsupportedIframeSrc. Lower-case prefix match.
+        private static readonly string[] _unsupportedIframeSchemes = new[]
+        {
+            "about:", "chrome:", "chrome-extension:", "devtools:", "edge:",
+            "opera:", "view-source:", "data:", "javascript:", "vbscript:", "blob:"
+        };
+
         private static bool IsCrossOriginFrame(string frameUrl, string pageUrl)
         {
-            if (frameUrl == "about:blank")
-                return false;
+            if (string.IsNullOrEmpty(frameUrl)) return false;
+            var lower = frameUrl.ToLowerInvariant();
+            foreach (var prefix in _unsupportedIframeSchemes)
+            {
+                if (lower.StartsWith(prefix)) return false;
+            }
 
             try
             {

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -92,7 +92,7 @@ namespace PercyIO.Playwright
         {
             if (_http == null)
             {
-                _http = new HttpClient();
+                setHttpClient(new HttpClient());
                 _http.Timeout = TimeSpan.FromMinutes(10);
             }
 
@@ -193,13 +193,13 @@ namespace PercyIO.Playwright
                 return (bool)(_enabled = false);
             }
         };
-        public class Region
-        {
-            public RegionElementSelector? elementSelector { get; set; }
-            public RegionPadding? padding { get; set; }
-            public string? algorithm { get; set; }
-            public RegionConfiguration? configuration { get; set; }
-            public RegionAssertion? assertion { get; set; }
+        public class Region 
+        { 
+            public RegionElementSelector elementSelector { get; set; } 
+            public RegionPadding padding { get; set; } 
+            public string algorithm { get; set; } 
+            public RegionConfiguration configuration { get; set; } 
+            public RegionAssertion assertion { get; set; } 
 
             // Rename the nested class to RegionElementSelector or another unique name
             public class RegionElementSelector 

--- a/Percy/Percy.cs
+++ b/Percy/Percy.cs
@@ -347,7 +347,14 @@ namespace PercyIO.Playwright
                 var root = docResult.Value.GetProperty("root");
 
                 var closedPairs = new List<(int hostId, int shadowId)>();
-                WalkNodes(root, closedPairs);
+                // Pass the page URL so WalkNodes can decide whether to recurse INTO
+                // an iframe's contentDocument: same-origin iframes share the parent
+                // page's JS realm + WeakMap, so closed shadow roots inside them must
+                // be collected too. Cross-origin iframes do NOT share the realm and
+                // are skipped entirely (their closed shadow roots are handled by the
+                // per-frame ProcessFrame path).
+                string pageUrl = page.Url ?? string.Empty;
+                WalkNodes(root, closedPairs, pageUrl);
 
                 if (closedPairs.Count == 0) return;
 
@@ -413,9 +420,34 @@ namespace PercyIO.Playwright
             }
         }
 
-        private static void WalkNodes(JsonElement node, List<(int hostId, int shadowId)> closedPairs)
+        private static void WalkNodes(JsonElement node, List<(int hostId, int shadowId)> closedPairs, string pageUrl)
         {
-            if (node.TryGetProperty("contentDocument", out _)) return;
+            // Same-origin iframe contentDocument trees: their closed shadow roots
+            // live in the parent page's JS realm, so PercyDOM.serialize() at the
+            // parent level needs them in window.__percyClosedShadowRoots too. We
+            // recurse INTO contentDocument only when same-origin; cross-origin
+            // frames have a separate realm and a separate WeakMap, so the per-frame
+            // ProcessFrame path handles them.
+            if (node.TryGetProperty("contentDocument", out var contentDoc))
+            {
+                string frameDocUrl = null!;
+                if (contentDoc.ValueKind == JsonValueKind.Object &&
+                    contentDoc.TryGetProperty("documentURL", out var docUrlEl) &&
+                    docUrlEl.ValueKind == JsonValueKind.String)
+                {
+                    frameDocUrl = docUrlEl.GetString() ?? string.Empty;
+                }
+
+                // IsCrossOriginFrame returns false for empty / unsupported schemes
+                // (about:blank, data:, blob:, etc.) — treat those as same-origin
+                // and recurse, matching the JS SDK behaviour.
+                if (!string.IsNullOrEmpty(pageUrl) &&
+                    !IsCrossOriginFrame(frameDocUrl ?? string.Empty, pageUrl))
+                {
+                    WalkNodes(contentDoc, closedPairs, pageUrl);
+                }
+                return;
+            }
 
             if (node.TryGetProperty("shadowRoots", out var shadowRoots))
             {
@@ -428,7 +460,7 @@ namespace PercyIO.Playwright
                             sr.GetProperty("backendNodeId").GetInt32()
                         ));
                     }
-                    WalkNodes(sr, closedPairs);
+                    WalkNodes(sr, closedPairs, pageUrl);
                 }
             }
 
@@ -436,7 +468,7 @@ namespace PercyIO.Playwright
             {
                 foreach (var child in children.EnumerateArray())
                 {
-                    WalkNodes(child, closedPairs);
+                    WalkNodes(child, closedPairs, pageUrl);
                 }
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@percy/cli": "1.31.10-alpha.0"
+        "@percy/cli": "1.31.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -67,20 +67,21 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-zxw3wxe6fVgrli2vdDm4Oa+GQ3GCnONlpQVP4Eb26tsm/koP2Yz83Gdtg4uLzgsYVGeyMXKklrkD1R0Zi1ZZzw==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.10.tgz",
+      "integrity": "sha512-vZLb9xcIHLNht+fuVpfFjd2WFvyRAnXumax9m4U2Y4Vyyao5fnHbeD7ME9PRuaiJPz0MNAHSANyEs1Mb3F7uAA==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-app": "1.31.10-alpha.0",
-        "@percy/cli-build": "1.31.10-alpha.0",
-        "@percy/cli-command": "1.31.10-alpha.0",
-        "@percy/cli-config": "1.31.10-alpha.0",
-        "@percy/cli-exec": "1.31.10-alpha.0",
-        "@percy/cli-snapshot": "1.31.10-alpha.0",
-        "@percy/cli-upload": "1.31.10-alpha.0",
-        "@percy/client": "1.31.10-alpha.0",
-        "@percy/logger": "1.31.10-alpha.0"
+        "@percy/cli-app": "1.31.10",
+        "@percy/cli-build": "1.31.10",
+        "@percy/cli-command": "1.31.10",
+        "@percy/cli-config": "1.31.10",
+        "@percy/cli-doctor": "1.31.10",
+        "@percy/cli-exec": "1.31.10",
+        "@percy/cli-snapshot": "1.31.10",
+        "@percy/cli-upload": "1.31.10",
+        "@percy/client": "1.31.10",
+        "@percy/logger": "1.31.10"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -90,39 +91,39 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-FmPKlMhV2TNweSCkqf2q+nElgU9RKIXZtGroH/Lq3enfYHo3SR1TaqQbua5ha4MnNZKqicEJhKIUqqCpUIg8DQ==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.10.tgz",
+      "integrity": "sha512-5lXqcjJESEksywdPHUJ43kLmfMCrUAZn1OPoVM+24S/Uo1Pcj2MBTrORJDip/pKJR+q+y5mAuXhx06ZfI7aGtw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.31.10-alpha.0",
-        "@percy/cli-exec": "1.31.10-alpha.0"
+        "@percy/cli-command": "1.31.10",
+        "@percy/cli-exec": "1.31.10"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-KIDAsGn7KCpNpdjOY5tMrDobPFG3oY6lmc9xwq0KX/2o1DcijQ6yn65zjN7iWIpTllW7IISLDSS2f4fK1Eishw==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.10.tgz",
+      "integrity": "sha512-AcendJyhNSv94bUvm4BSQZZkb6a2eZxH8tSqIDgiDDuvTYTpfyAg07Wo25k+SojNKwTbV8jO4f8yXtYXA7UOgw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.31.10-alpha.0"
+        "@percy/cli-command": "1.31.10"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-eH/mL0KUWC5kfWpNk98e8ZkRqMPOAAhOidVwDRk89i1vdu47dJPr+mD5T11ycCCQCkbyCyk1Z+prNuBg2AKqmA==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.10.tgz",
+      "integrity": "sha512-S37xCuYEo5f5vY8FGoAHwyP91pJY3hZkDBppv9MqY4QTW3QrtRaJqGqvrfo7bI9iO7Z5bAGc1uXQeYY25Ix6eA==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.31.10-alpha.0",
-        "@percy/core": "1.31.10-alpha.0",
-        "@percy/logger": "1.31.10-alpha.0"
+        "@percy/config": "1.31.10",
+        "@percy/core": "1.31.10",
+        "@percy/logger": "1.31.10"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -132,25 +133,45 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-Pf8QCCW3yKBYRR3r0FCA++8pFshHpBzLkZnlHOYXEE1vY83KI7M0+1/5gwmB7JNhiVS9CLsX+nz2MG+DBf1lRA==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.10.tgz",
+      "integrity": "sha512-9+aUbYb+ecTvZF7W1m8dh/zxTXoB8JOOhyPyX7h/K1J/ai00syfRj5+agtrLafDilQBnFSIsikWEZYWiM+maIw==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.31.10-alpha.0"
+        "@percy/cli-command": "1.31.10"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@percy/cli-doctor": {
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli-doctor/-/cli-doctor-1.31.10.tgz",
+      "integrity": "sha512-sgn1hBxS/Q890DSj1Cdw/rQAtYbdPD2AUtfUnCCQsaGVN8U9jI93KGh7G/Sd0kU1iKlQQeo/2PMlgzF4JZdbDw==",
+      "dev": true,
+      "dependencies": {
+        "@percy/cli-command": "1.31.10",
+        "@percy/client": "1.31.10",
+        "@percy/config": "1.31.10",
+        "@percy/core": "1.31.10",
+        "@percy/env": "1.31.10",
+        "@percy/logger": "1.31.10",
+        "@percy/monitoring": "1.31.10",
+        "minimatch": "^9.0.0",
+        "ws": "^8.17.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-24jvvI53XjPvBhz+CXl9HEOWdQM3mIqQWaB5CachLFDJTlxBjrJsYlh3SSQh41lvyX/Qc0IWFYifq7xDzuGGLQ==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.10.tgz",
+      "integrity": "sha512-A+PNB29joAL/p+7Q4mv9jE/amnraUHpR5jXa8VWHgNyB8ktl9qit46tbR6ts1qFu4IziT93txbOWPdlTxIpJWA==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.31.10-alpha.0",
-        "@percy/logger": "1.31.10-alpha.0",
+        "@percy/cli-command": "1.31.10",
+        "@percy/logger": "1.31.10",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -159,12 +180,12 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-V8LjWPw9L0O1YuJVDN9qRGa+H8ZV0hUMYyL2YYTvKGTIXB+BTY5EmUPOCT9hMJrWgLoUEPIOhntk8qDRyPTssg==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.10.tgz",
+      "integrity": "sha512-wK40uRW7j9ahMnyMWzJw+M5uf8OpRsMD7DAk88TibAWxKELmwEFxNSKBm/MUK413W5+lw3Xvza7xrUnu+cecGg==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.31.10-alpha.0",
+        "@percy/cli-command": "1.31.10",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -172,12 +193,12 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-2h09Q0c8RTxzsN3Wev2rxlhsh4YLfQoCSoXpuODaKTCAQyd7PuoF6sKl7bFm7J/CdT3yIbsSKOemKoyiW4YSew==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.10.tgz",
+      "integrity": "sha512-X4aGL/gwdB0IvT+caivuSBqREFh4B+6W414Cm8z1jS7H4LvYGEBqH3VHAAC60EvyvAdiGMBp6z/CekViiU6f2Q==",
       "dev": true,
       "dependencies": {
-        "@percy/cli-command": "1.31.10-alpha.0",
+        "@percy/cli-command": "1.31.10",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -186,14 +207,14 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-NU+2SPqtd3Ry/dIk0Y0pke4gxtkW+d6OF/7O9juvcgXzB48WnqOel58cejpVq6pJg5xk60BoZJ7JkQmSUtXtyQ==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.10.tgz",
+      "integrity": "sha512-gaHWoVuU3bZUtLAjxHHKVVEMrEZ8b4jRJXF8RIFapI5j30yJJ87zfmo+3qYzolvTcOjUCypFhterVrJGa+uJGA==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.31.10-alpha.0",
-        "@percy/env": "1.31.10-alpha.0",
-        "@percy/logger": "1.31.10-alpha.0",
+        "@percy/config": "1.31.10",
+        "@percy/env": "1.31.10",
+        "@percy/logger": "1.31.10",
         "pac-proxy-agent": "^7.0.2",
         "pako": "^2.1.0"
       },
@@ -202,12 +223,12 @@
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-d73a3iM8d7l5lWqjPtIQI4POwm8SL4vL2w0UJcDoMjOXqIM2ElJDDwzwBaZqVDLuyfKZb1twLSTdmOOYWGJG9w==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.10.tgz",
+      "integrity": "sha512-X1hxR0IH0hL6uKCIytn+4pidQb/NH6qJBcJTCNxHJ+iXBU67iAtHziwA9Ph2XYemMa24QU2rE2Lq4897BhJ8fg==",
       "dev": true,
       "dependencies": {
-        "@percy/logger": "1.31.10-alpha.0",
+        "@percy/logger": "1.31.10",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
@@ -217,18 +238,18 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-baRQuReoXam+Ucii21HZZBkvsgQRAZkpEnxcQj5CkCUel+T0mSu+EXAMTyGG+3ikk3CXaYsAxcPuTrCeMwNVMw==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.10.tgz",
+      "integrity": "sha512-8Yfp03+qgT6lnAvDbdk8yAYC7Lm8GZx+eTvTn9TvbVXtZZ1ru1OJFNj2owJW7KStrIrOd4kRssv6zVBgD9qH2A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@percy/client": "1.31.10-alpha.0",
-        "@percy/config": "1.31.10-alpha.0",
-        "@percy/dom": "1.31.10-alpha.0",
-        "@percy/logger": "1.31.10-alpha.0",
-        "@percy/monitoring": "1.31.10-alpha.0",
-        "@percy/webdriver-utils": "1.31.10-alpha.0",
+        "@percy/client": "1.31.10",
+        "@percy/config": "1.31.10",
+        "@percy/dom": "1.31.10",
+        "@percy/logger": "1.31.10",
+        "@percy/monitoring": "1.31.10",
+        "@percy/webdriver-utils": "1.31.10",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -243,44 +264,47 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "optionalDependencies": {
+        "@percy/cli-doctor": "1.31.10"
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-wWuqMxxucCR4G2a550Y2P+ISRoLULer+ZF6aHfrgH5TchnKnHcdnEHQfZclY/U8EVhfs5LeZP+WRjetSC30KAg==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.10.tgz",
+      "integrity": "sha512-9qM8FrwgOsJo49qpzUZZ4018R9K26OEZt1CabdH3WHozEuLgk12uHsW3skuQlqVCx1qIhOz3wsp0ounVcQbZZQ==",
       "dev": true
     },
     "node_modules/@percy/env": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-1zqNzazuNTODbqs91VJoTT5Cp0WxCooJFekeYYi/QPJzRC0eGL7+R5r2p2MV+oqa/pWSvb/uwUNBfw6YEn71+Q==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.10.tgz",
+      "integrity": "sha512-cF8tsjO7L4v35g77Msjf03nnSfG1QU0bmdtosEnIzc3BknzPgSfMpz5Y4DyylNxMumf1m3ZSnjel0H96O+dxzQ==",
       "dev": true,
       "dependencies": {
-        "@percy/logger": "1.31.10-alpha.0"
+        "@percy/logger": "1.31.10"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-Eq/DP0mr15YsbSRKlSHLaJwMLuEyHZrpMkNACP/dpuSdWA5qmbwkBrYPM7jdkystpJccGkm04eKg9YUesMwUFQ==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.10.tgz",
+      "integrity": "sha512-h870huTL8ebLRkyqXuJGDFaGXKXvQ6JkHH49q6zLZlkzUnASeN23pkDhH14IsaZmpbGJN0x7S7560m77bue67A==",
       "dev": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/monitoring": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-skQQLRzDzmJnPld90aFOMP7gP1xLKTMk1QP8ToUvsv3ZkPTOxwRvDysooIvfnFsgfrD9XZzS576krXeNTfvneg==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.10.tgz",
+      "integrity": "sha512-BCJj6rptDDcocI8PqE++gKpaOzhGgkTfzzgjqKxWp7ElQdwe+WL7J/YdCiMzG5EvLYe1ly8gNVMvoWqk+kfjhA==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.31.10-alpha.0",
-        "@percy/logger": "1.31.10-alpha.0",
-        "@percy/sdk-utils": "1.31.10-alpha.0",
+        "@percy/config": "1.31.10",
+        "@percy/logger": "1.31.10",
+        "@percy/sdk-utils": "1.31.10",
         "systeminformation": "^5.25.11"
       },
       "engines": {
@@ -288,9 +312,9 @@
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-CPD2MY/zrrZuR84x/dBuaqnmimZf+ugvYrKkEapO3DEgB9ce3A++h/WMhbkwGOCzzfXDossTNcTmDro8o2YdJw==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.10.tgz",
+      "integrity": "sha512-ha4keZdNJunRcKLOJOTMW7c/zpiz0MLSwLbHTshjpiEeYjJS73nuwRR5tzqoq4GDOC1BP/dBV+UuM9trlow8UQ==",
       "dev": true,
       "dependencies": {
         "pac-proxy-agent": "^7.0.2"
@@ -300,13 +324,13 @@
       }
     },
     "node_modules/@percy/webdriver-utils": {
-      "version": "1.31.10-alpha.0",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.10-alpha.0.tgz",
-      "integrity": "sha512-ue6ELvi2PPAdSOvzXwWYBmteAUuig9IUqrKbgyremhvaTcdArx0eSTeek5lbHTPq/SyamhfYm58eYe5w2mTkCg==",
+      "version": "1.31.10",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.10.tgz",
+      "integrity": "sha512-ot0yAvg6tQSCrP6b6xQ5UhysswEq5jA7Yq2PDb4hv50oZy6EfBT4HpCehXF2F6nKGngWFwVnzoUJrhFxsBdazw==",
       "dev": true,
       "dependencies": {
-        "@percy/config": "1.31.10-alpha.0",
-        "@percy/sdk-utils": "1.31.10-alpha.0"
+        "@percy/config": "1.31.10",
+        "@percy/sdk-utils": "1.31.10"
       },
       "engines": {
         "node": ">=14"
@@ -319,13 +343,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "25.3.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
-      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.21.0"
       }
     },
     "node_modules/@types/yauzl": {
@@ -348,9 +372,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -388,22 +412,21 @@
       "dev": true
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -647,9 +670,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -760,6 +783,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -835,9 +880,9 @@
       "dev": true
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "engines": {
         "node": ">= 12"
@@ -965,15 +1010,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -983,9 +1031,9 @@
       "dev": true
     },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
@@ -1114,9 +1162,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -1283,12 +1331,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -1321,9 +1369,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.3",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.3.tgz",
-      "integrity": "sha512-vX0eeI7oGIr79NLiJRWnK8SyxDjyiNOEanaQnHRNyb5ep8QcpD8QMDvrukdrxV4pV4AKjwUDfaypXnWHMC/65A==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
+      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
       "dev": true,
       "os": [
         "darwin",
@@ -1365,9 +1413,9 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "dev": true,
       "optional": true
     },
@@ -1393,9 +1441,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -1414,9 +1462,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "bin": {
         "yaml": "bin.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@percy/cli": "1.31.10"
+        "@percy/cli": "1.31.14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -13,6 +13,7 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -27,6 +28,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -36,6 +38,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -49,6 +52,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -58,6 +62,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -67,21 +72,22 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.10.tgz",
-      "integrity": "sha512-vZLb9xcIHLNht+fuVpfFjd2WFvyRAnXumax9m4U2Y4Vyyao5fnHbeD7ME9PRuaiJPz0MNAHSANyEs1Mb3F7uAA==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.14.tgz",
+      "integrity": "sha512-/gaJJz+Em4nVFAq57tDPg2IY+ju5ORrANZP/xHBp6koNhEnzwpgkgDRU23jUsPiNQ2UO3uKnlpzbRhvfUuhAPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/cli-app": "1.31.10",
-        "@percy/cli-build": "1.31.10",
-        "@percy/cli-command": "1.31.10",
-        "@percy/cli-config": "1.31.10",
-        "@percy/cli-doctor": "1.31.10",
-        "@percy/cli-exec": "1.31.10",
-        "@percy/cli-snapshot": "1.31.10",
-        "@percy/cli-upload": "1.31.10",
-        "@percy/client": "1.31.10",
-        "@percy/logger": "1.31.10"
+        "@percy/cli-app": "1.31.14",
+        "@percy/cli-build": "1.31.14",
+        "@percy/cli-command": "1.31.14",
+        "@percy/cli-config": "1.31.14",
+        "@percy/cli-doctor": "1.31.14",
+        "@percy/cli-exec": "1.31.14",
+        "@percy/cli-snapshot": "1.31.14",
+        "@percy/cli-upload": "1.31.14",
+        "@percy/client": "1.31.14",
+        "@percy/logger": "1.31.14"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -91,39 +97,42 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.10.tgz",
-      "integrity": "sha512-5lXqcjJESEksywdPHUJ43kLmfMCrUAZn1OPoVM+24S/Uo1Pcj2MBTrORJDip/pKJR+q+y5mAuXhx06ZfI7aGtw==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.14.tgz",
+      "integrity": "sha512-V9L8EiLYzPsD1W4Rot3cBEYCrr81ZSseJEiHKtYCCWcjZYk5kTZdFJc8YjYE3KLFMUkxVIcRmCQeHE5Awcu8RA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.10",
-        "@percy/cli-exec": "1.31.10"
+        "@percy/cli-command": "1.31.14",
+        "@percy/cli-exec": "1.31.14"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.10.tgz",
-      "integrity": "sha512-AcendJyhNSv94bUvm4BSQZZkb6a2eZxH8tSqIDgiDDuvTYTpfyAg07Wo25k+SojNKwTbV8jO4f8yXtYXA7UOgw==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.14.tgz",
+      "integrity": "sha512-jxp+XRxKJ3xr3ZKmjpaHI1oY5OMuPYvWP/EBzzPxUi8vbmJe5pMxjj9EplcnTJYCABsfQviwazedbrCDitYdPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.10"
+        "@percy/cli-command": "1.31.14"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.10.tgz",
-      "integrity": "sha512-S37xCuYEo5f5vY8FGoAHwyP91pJY3hZkDBppv9MqY4QTW3QrtRaJqGqvrfo7bI9iO7Z5bAGc1uXQeYY25Ix6eA==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.14.tgz",
+      "integrity": "sha512-rLDR8dqHuUMQf4QfoStcQ1YTjdahGHOLn8IgA4ZC/o0H/9o2ynDIckMfQRgPYwBSwJDZU/pFZmuFGXiC8l/3tw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.31.10",
-        "@percy/core": "1.31.10",
-        "@percy/logger": "1.31.10"
+        "@percy/config": "1.31.14",
+        "@percy/core": "1.31.14",
+        "@percy/logger": "1.31.14"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -133,30 +142,32 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.10.tgz",
-      "integrity": "sha512-9+aUbYb+ecTvZF7W1m8dh/zxTXoB8JOOhyPyX7h/K1J/ai00syfRj5+agtrLafDilQBnFSIsikWEZYWiM+maIw==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.14.tgz",
+      "integrity": "sha512-wz/mmJMRSEfSVtD26aeorx5ZpzDw2SuETM6CxbNS1+SPvQT+NyKTWoqjOmboBn3AmVq4IYoRgbAfz/irOSkhZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.10"
+        "@percy/cli-command": "1.31.14"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-doctor": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli-doctor/-/cli-doctor-1.31.10.tgz",
-      "integrity": "sha512-sgn1hBxS/Q890DSj1Cdw/rQAtYbdPD2AUtfUnCCQsaGVN8U9jI93KGh7G/Sd0kU1iKlQQeo/2PMlgzF4JZdbDw==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-doctor/-/cli-doctor-1.31.14.tgz",
+      "integrity": "sha512-UjH6LUvAWoX3HUFg9qcxo7bRVb6Y41/RCFYbAdC+/jZF/IX+FU3wnmGD8s0FZs4L+wlz6PXSJtIzAcyQGRas1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.10",
-        "@percy/client": "1.31.10",
-        "@percy/config": "1.31.10",
-        "@percy/core": "1.31.10",
-        "@percy/env": "1.31.10",
-        "@percy/logger": "1.31.10",
-        "@percy/monitoring": "1.31.10",
+        "@percy/cli-command": "1.31.14",
+        "@percy/client": "1.31.14",
+        "@percy/config": "1.31.14",
+        "@percy/core": "1.31.14",
+        "@percy/env": "1.31.14",
+        "@percy/logger": "1.31.14",
+        "@percy/monitoring": "1.31.14",
         "minimatch": "^9.0.0",
         "ws": "^8.17.1"
       },
@@ -165,13 +176,14 @@
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.10.tgz",
-      "integrity": "sha512-A+PNB29joAL/p+7Q4mv9jE/amnraUHpR5jXa8VWHgNyB8ktl9qit46tbR6ts1qFu4IziT93txbOWPdlTxIpJWA==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.14.tgz",
+      "integrity": "sha512-Vs7Tulw2tM4Z/tDLpU/Stc+29hHl3g8Z5gfIPBPBfcTcIp4Ws6F7tKDO0NBzXsIGv9JuLhnc2zQvEIPCrDcV0Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.10",
-        "@percy/logger": "1.31.10",
+        "@percy/cli-command": "1.31.14",
+        "@percy/logger": "1.31.14",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -180,12 +192,13 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.10.tgz",
-      "integrity": "sha512-wK40uRW7j9ahMnyMWzJw+M5uf8OpRsMD7DAk88TibAWxKELmwEFxNSKBm/MUK413W5+lw3Xvza7xrUnu+cecGg==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.14.tgz",
+      "integrity": "sha512-JdE8mJ0PSwSO5T4V0B1qrM5SP1MPCssQTkcPgnUY2ykNKS7ePr6vzd4USn/Ex4rqIJydT6MeoUPptV051owsRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.10",
+        "@percy/cli-command": "1.31.14",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -193,12 +206,13 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.10.tgz",
-      "integrity": "sha512-X4aGL/gwdB0IvT+caivuSBqREFh4B+6W414Cm8z1jS7H4LvYGEBqH3VHAAC60EvyvAdiGMBp6z/CekViiU6f2Q==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.14.tgz",
+      "integrity": "sha512-VEhjW4hnRJAnYWoqLnFsJJ0m3JXohPBOPoqUtL3/P3fgXvWfVYtavSwlgjrWmS7YZ0z6gIT02Isd6i8wwnIGAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.31.10",
+        "@percy/cli-command": "1.31.14",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -207,14 +221,15 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.10.tgz",
-      "integrity": "sha512-gaHWoVuU3bZUtLAjxHHKVVEMrEZ8b4jRJXF8RIFapI5j30yJJ87zfmo+3qYzolvTcOjUCypFhterVrJGa+uJGA==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.14.tgz",
+      "integrity": "sha512-HA/1SlYg57L3eNQZivNJ5yKZte8v7ZZ3CT29hhn03sHReVd3NshQuSC1Vm8kchrnoSi4SR5bUilwJ9w8lnDT3A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.31.10",
-        "@percy/env": "1.31.10",
-        "@percy/logger": "1.31.10",
+        "@percy/config": "1.31.14",
+        "@percy/env": "1.31.14",
+        "@percy/logger": "1.31.14",
         "pac-proxy-agent": "^7.0.2",
         "pako": "^2.1.0"
       },
@@ -223,12 +238,13 @@
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.10.tgz",
-      "integrity": "sha512-X1hxR0IH0hL6uKCIytn+4pidQb/NH6qJBcJTCNxHJ+iXBU67iAtHziwA9Ph2XYemMa24QU2rE2Lq4897BhJ8fg==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.14.tgz",
+      "integrity": "sha512-BRVfkff1j3ATdA8xH600802nhFfE1K4XRsGwOHTEZd/DnFVvGUIagQvfZxpTdHBTZ8G+nwi9Z8CTcVtzgd4AMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.31.10",
+        "@percy/logger": "1.31.14",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
@@ -238,18 +254,19 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.10.tgz",
-      "integrity": "sha512-8Yfp03+qgT6lnAvDbdk8yAYC7Lm8GZx+eTvTn9TvbVXtZZ1ru1OJFNj2owJW7KStrIrOd4kRssv6zVBgD9qH2A==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.14.tgz",
+      "integrity": "sha512-c6QTjqaKs7UxL9HK6VJJl5B57hywFNn+l22vES4dFkegrkdE0maAz7rG88X2Xp2sYrsR3qf9n9CKCDy511/KYw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/client": "1.31.10",
-        "@percy/config": "1.31.10",
-        "@percy/dom": "1.31.10",
-        "@percy/logger": "1.31.10",
-        "@percy/monitoring": "1.31.10",
-        "@percy/webdriver-utils": "1.31.10",
+        "@percy/client": "1.31.14",
+        "@percy/config": "1.31.14",
+        "@percy/dom": "1.31.14",
+        "@percy/logger": "1.31.14",
+        "@percy/monitoring": "1.31.14",
+        "@percy/webdriver-utils": "1.31.14",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -266,45 +283,49 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@percy/cli-doctor": "1.31.10"
+        "@percy/cli-doctor": "1.31.14"
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.10.tgz",
-      "integrity": "sha512-9qM8FrwgOsJo49qpzUZZ4018R9K26OEZt1CabdH3WHozEuLgk12uHsW3skuQlqVCx1qIhOz3wsp0ounVcQbZZQ==",
-      "dev": true
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.14.tgz",
+      "integrity": "sha512-Ilz9qSf9Z80jHah9b7OfX2M2N9vmY4hkGEhMO953ui3NSQhXZsezr4aIPREYdyZdo11pEWm+JWU1AEZw54CbbA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@percy/env": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.10.tgz",
-      "integrity": "sha512-cF8tsjO7L4v35g77Msjf03nnSfG1QU0bmdtosEnIzc3BknzPgSfMpz5Y4DyylNxMumf1m3ZSnjel0H96O+dxzQ==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.14.tgz",
+      "integrity": "sha512-eRW4Ot2Z5WESKPJHcdLc9JFLtjxJaALzRxGa7Z+0R5t5wOlqbEVQytLBzgFWWTVa2XEejR4Sffs5cYqM+ldgEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.31.10"
+        "@percy/logger": "1.31.14"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.10.tgz",
-      "integrity": "sha512-h870huTL8ebLRkyqXuJGDFaGXKXvQ6JkHH49q6zLZlkzUnASeN23pkDhH14IsaZmpbGJN0x7S7560m77bue67A==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.14.tgz",
+      "integrity": "sha512-e078iCrSDa4qdMfOlX+DXhZ08MzYxNTFfz7HsgLcAXSn6AV+CGZT/BxaHlzm2I5tp1zQV7wHnvvm4RV2qx1FEA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/monitoring": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.10.tgz",
-      "integrity": "sha512-BCJj6rptDDcocI8PqE++gKpaOzhGgkTfzzgjqKxWp7ElQdwe+WL7J/YdCiMzG5EvLYe1ly8gNVMvoWqk+kfjhA==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.14.tgz",
+      "integrity": "sha512-5zqOZmkua08pc/lppXeBUCEWCG9xGQwrxI+DlZ6TMLg05Dwn7nPRaMMxYla8A/XsDemcq0TECgCT83uYY0WpeQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.31.10",
-        "@percy/logger": "1.31.10",
-        "@percy/sdk-utils": "1.31.10",
+        "@percy/config": "1.31.14",
+        "@percy/logger": "1.31.14",
+        "@percy/sdk-utils": "1.31.14",
         "systeminformation": "^5.25.11"
       },
       "engines": {
@@ -312,10 +333,11 @@
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.10.tgz",
-      "integrity": "sha512-ha4keZdNJunRcKLOJOTMW7c/zpiz0MLSwLbHTshjpiEeYjJS73nuwRR5tzqoq4GDOC1BP/dBV+UuM9trlow8UQ==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.14.tgz",
+      "integrity": "sha512-I31GM+aCHiME12jX9ac5COThZWOpTBONkR9J6D059wqiFhHtRenA2mWFx6rC+zUpG5un0imkal7tN9y1D4hPBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pac-proxy-agent": "^7.0.2"
       },
@@ -324,13 +346,14 @@
       }
     },
     "node_modules/@percy/webdriver-utils": {
-      "version": "1.31.10",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.10.tgz",
-      "integrity": "sha512-ot0yAvg6tQSCrP6b6xQ5UhysswEq5jA7Yq2PDb4hv50oZy6EfBT4HpCehXF2F6nKGngWFwVnzoUJrhFxsBdazw==",
+      "version": "1.31.14",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.14.tgz",
+      "integrity": "sha512-2V4yxf60mXsDAUz+GFOePcfSNF9mSbrV1WH+sUWDItFUjV14QSVNuBcZRKO8Etgi7bFSCPz1Z1jXrxmopBFpbg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.31.10",
-        "@percy/sdk-utils": "1.31.10"
+        "@percy/config": "1.31.14",
+        "@percy/sdk-utils": "1.31.14"
       },
       "engines": {
         "node": ">=14"
@@ -340,16 +363,18 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/yauzl": {
@@ -357,6 +382,7 @@
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -367,6 +393,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -376,6 +403,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -391,13 +419,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -409,13 +439,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/basic-ftp": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
       "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -425,6 +457,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -434,6 +467,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -446,6 +480,7 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -455,6 +490,7 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -463,13 +499,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -482,6 +520,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -508,6 +547,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -522,6 +562,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -531,6 +572,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -548,6 +590,7 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -562,6 +605,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -571,6 +615,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -580,6 +625,7 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -601,6 +647,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -614,6 +661,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -623,6 +671,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -632,6 +681,7 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -651,13 +701,15 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -683,13 +735,15 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -699,6 +753,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -708,6 +763,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -719,13 +775,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -741,6 +799,7 @@
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -756,6 +815,7 @@
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -776,6 +836,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -788,6 +849,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -798,6 +860,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -810,6 +873,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -823,6 +887,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -836,6 +901,7 @@
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
       "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "queue": "6.0.2"
       },
@@ -851,6 +917,7 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -868,6 +935,7 @@
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -877,13 +945,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -892,13 +962,15 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -908,6 +980,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -920,6 +993,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -928,19 +1002,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -952,25 +1029,29 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -980,6 +1061,7 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -993,6 +1075,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1002,6 +1085,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -1014,6 +1098,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -1028,13 +1113,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/netmask": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
       "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -1044,6 +1131,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -1053,6 +1141,7 @@
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -1072,6 +1161,7 @@
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -1084,13 +1174,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "dev": true
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -1103,6 +1195,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -1121,6 +1214,7 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1130,6 +1224,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1138,13 +1233,15 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1153,19 +1250,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1178,6 +1278,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -1188,6 +1289,7 @@
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.3"
       }
@@ -1210,13 +1312,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1226,6 +1330,7 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -1235,6 +1340,7 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -1246,6 +1352,7 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -1275,6 +1382,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -1297,13 +1405,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -1316,6 +1426,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1325,6 +1436,7 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -1335,6 +1447,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
@@ -1349,6 +1462,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -1363,6 +1477,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1373,6 +1488,7 @@
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
       "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
       "dev": true,
+      "license": "MIT",
       "os": [
         "darwin",
         "linux",
@@ -1399,6 +1515,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1410,13 +1527,15 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/which": {
@@ -1424,6 +1543,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -1438,13 +1558,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1466,6 +1588,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -1481,6 +1604,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "test": "percy exec --testing -- dotnet test"
   },
   "devDependencies": {
-    "@percy/cli": "1.31.10"
+    "@percy/cli": "1.31.14"
   }
 }


### PR DESCRIPTION
## Summary
- Capture closed shadow roots in Chromium-backed Playwright tests by walking the DOM via CDP (`DOM.getDocument` + `DOM.describeNode`) and exposing the closed roots to the serializer before `PercyDOM.serialize` runs. Mirrors the closed-shadow approach already shipped in percy-selenium-{js,java,python,ruby,dotnet} and percy-playwright-{java,python}.
- Harden HTTP client init with double-checked locking so concurrent first-callers can't observe a half-built `HttpClient` (default 100s timeout). Matches `Percy.Selenium`.
- Broaden `IsCrossOriginFrame` to skip iframes whose `src` uses `about:`, `chrome:`, `chrome-extension:`, `devtools:`, `edge:`, `opera:`, `view-source:`, `data:`, `javascript:`, `vbscript:`, or `blob:`. Previously only `about:blank` was excluded.

## Scope vs. epic
Part of PER-7292 / [Increased DOM Structures Coverage](https://browserstack.atlassian.net/wiki/x/AYDraQE). This PR ships the **closed shadow DOM via CDP** slice for the .NET Playwright SDK; sibling PRs across the other SDKs cover nested CORS iframes, ignore selectors, and partial-capture recovery. Sandboxed/dynamic iframes, Web Components lifecycle, and the capture-fidelity indicator UI are not in scope here.

## Test plan
- [ ] `dotnet test` against a page containing a closed shadow root — verify the snapshot includes the closed-root subtree
- [ ] Sanity-check a single-threaded run still works (no deadlock from the new lock)
- [ ] Snapshot a page embedding `data:`, `about:blank`, and `chrome-extension:` iframes — verify none are treated as cross-origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)