### PR TITLE
chore: release 1.0.4-beta.0

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -11,7 +11,7 @@
     <PackageId>PercyIO.Playwright</PackageId>
     <Description>Percy for Playwright Driver API .NET Bindings</Description>
     <PackageTags>playwright;percy;visual;testing</PackageTags>
-    <Version>1.0.3</Version>
+    <Version>1.0.4-beta.0</Version>
     <Company>BrowserStack</Company>
     <Copyright>Copyright BrowserStack</Copyright>
     <Authors>BrowserStack</Authors>


### PR DESCRIPTION
Beta release: ships PER-7348 readiness gate (waitForReady before serialize) via `@percy/cli@^1.31.15-beta.0`.

Merged in this line:
- #210 — readiness gate

Test plan:
- [ ] CI green
- [ ] nuget tag verified after merge