### PR TITLE
bump version to v1.0.4

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -11,7 +11,7 @@
     <PackageId>PercyIO.Playwright</PackageId>
     <Description>Percy for Playwright Driver API .NET Bindings</Description>
     <PackageTags>playwright;percy;visual;testing</PackageTags>
-    <Version>1.0.4-beta.0</Version>
+    <Version>1.0.4</Version>
     <Company>BrowserStack</Company>
     <Copyright>Copyright BrowserStack</Copyright>
     <Authors>BrowserStack</Authors>


### PR DESCRIPTION
## Summary
Promote `1.0.4-beta.0` → `1.0.4` stable, following the repo's beta.0 → stable release convention (e.g. #203 for v1.0.3).

The 1.0.4 line includes:
- Closed shadow DOM capture via CDP (#228)
- PER-7348 `waitForReady()` readiness gate before serialize (#210)
- Responsive snapshot capture, CORS iframe serialization, cookie injection (#184)

## Change
Single-line `<Version>` bump in `Percy/Percy.csproj`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)