### PR TITLE
bump version to v1.0.4-beta.1

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -11,7 +11,7 @@
     <PackageId>PercyIO.Playwright</PackageId>
     <Description>Percy for Playwright Driver API .NET Bindings</Description>
     <PackageTags>playwright;percy;visual;testing</PackageTags>
-    <Version>1.0.4-beta.0</Version>
+    <Version>1.0.4-beta.1</Version>
     <Company>BrowserStack</Company>
     <Copyright>Copyright BrowserStack</Copyright>
     <Authors>BrowserStack</Authors>


### PR DESCRIPTION
## Summary
Beta vbump: `1.0.4-beta.0` → `1.0.4-beta.1` (stays in beta). Picks up changes merged onto `main` since beta.0:
- Closed shadow DOM capture via CDP (#228)
- Coverage gate (#236)

## Change
Single-line `<Version>` bump in `Percy/Percy.csproj`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)