### PR TITLE
release v1.0.4-beta.2

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -11,7 +11,7 @@
     <PackageId>PercyIO.Playwright</PackageId>
     <Description>Percy for Playwright Driver API .NET Bindings</Description>
     <PackageTags>playwright;percy;visual;testing</PackageTags>
-    <Version>1.0.4-beta.1</Version>
+    <Version>1.0.4-beta.2</Version>
     <Company>BrowserStack</Company>
     <Copyright>Copyright BrowserStack</Copyright>
     <Authors>BrowserStack</Authors>


### PR DESCRIPTION
Bumps the SDK to the next beta (`1.0.4-beta.1` → `1.0.4-beta.2`) for a beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)